### PR TITLE
Bugfix to #11, #12, #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ python llm_generate --prompt "Your prompt here"
 Example:
 
 ```bash
-curl -X POST "http://localhost:8000/ocr" -F "file=examples/example-mri.pdf" -F "strategy=marker" -F "ocr_cache=true"
+curl -X POST -H "Content-Type: multipart/form-data" -F "data=examples/example-mri.pdf" -F "strategy=marker" -F "ocr_cache=true" -F "prompt=" -F "model=" "http://localhost:8000/ocr" 
 ```
 
 ### OCR Result Endpoint

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -19,7 +19,7 @@ services:
       - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND-redis://redis:6379/0}
       - LLM_PULL_API_URL=${LLM_PULL_API_URL-http://web:8000/llm_pull}
       - LLM_GENEREATE_API_URL=${LLM_GENEREATE_API_URL-http://web:8000/llm_generate}
-      - OLLAMA_HOST${OLLAMA_HOST-http://ollama:11434}
+      - OLLAMA_HOST=${OLLAMA_HOST-http://ollama:11434}
       - APP_ENV=${APP_ENV-development}  # Default to development mode
     depends_on:
       - redis

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -60,7 +60,7 @@ services:
 
 
   ollama:
-    image: ollama/ollama:latest  # Use the official Ollama image
+    image: ollama/ollama:0.4.0-rc6-rocm # Use the official Ollama image
     container_name: ollama
     pull_policy: always
     tty: true
@@ -68,7 +68,7 @@ services:
     ports:
       - "11434:11434"  # Expose Ollama's API port, changing internal to external port
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/health"]  # Assumes health endpoint exists
+      test: ["CMD", "curl", "-f", "http://localhost:11434/"]  # Assumes health endpoint exists
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND-redis://redis:6379/0}
       - LLM_PULL_API_URL=${LLM_PULL_API_URL-http://web:8000/llm_pull}
       - LLM_GENEREATE_API_URL=${LLM_GENEREATE_API_URL-http://web:8000/llm_generate}
-      - OLLAMA_HOST${OLLAMA_HOST-http://ollama:11434}
+      - OLLAMA_HOST=${OLLAMA_HOST-http://ollama:11434}
       - APP_ENV=${APP_ENV-development}  # Default to development mode
     depends_on:
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
 
   ollama:
-    image: ollama/ollama:latest  # Use the official Ollama image
+    image: ollama/ollama:0.4.0-rc6-rocm  # Use the official Ollama image
     container_name: ollama
     pull_policy: always
     tty: true
@@ -53,7 +53,7 @@ services:
     ports:
       - "11434:11434"  # Expose Ollama's API port, changing internal to external port
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/health"]  # Assumes health endpoint exists
+      test: ["CMD", "curl", "-f", "http://localhost:11434/"]  # Assumes health endpoint exists
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
- README `ocr` command fix - setting `data=` instead of `file=` when uploading curl file
- fixed env variable `OLLAMA_HOST` (there was just a typo in the `docker-compose.yml`)
- changed the `ollama` image version to specific one instead of latest + `healthcheck` endpoint fixed